### PR TITLE
Zalo integration in UAParser

### DIFF
--- a/src/enums/ua-parser-enums.d.ts
+++ b/src/enums/ua-parser-enums.d.ts
@@ -152,6 +152,7 @@ export const Browser: Readonly<{
     WHALE: "Whale";
     WOLVIC: "Wolvic";
     YANDEX: "Yandex";
+    ZALO: "Zalo";
 }>;
 export const BrowserType: Readonly<{
     CRAWLER: "crawler";

--- a/src/enums/ua-parser-enums.js
+++ b/src/enums/ua-parser-enums.js
@@ -156,7 +156,8 @@ const Browser = Object.freeze({
     WEIBO: 'Weibo',
     WHALE: 'Whale',
     WOLVIC: 'Wolvic',
-    YANDEX: 'Yandex'
+    YANDEX: 'Yandex',
+    ZALO: 'Zalo'
 
     // TODO : test!
 });

--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -426,7 +426,8 @@
             /\b(line)\/([\w\.]+)\/iab/i,                                        // Line App for Android
             /(alipay)client\/([\w\.]+)/i,                                       // Alipay
             /(twitter)(?:and| f.+e\/([\w\.]+))/i,                               // Twitter
-            /(instagram|snapchat)[\/ ]([-\w\.]+)/i                              // Instagram/Snapchat
+            /(instagram|snapchat)[\/ ]([-\w\.]+)/i,                             // Instagram/Snapchat
+            /(zalo(?:app)?|zalo pay(?:client)?)[\/\sa-z]*([\w\.-]+)/i           // Zalo App
             ], [NAME, VERSION, [TYPE, INAPP]], [
             /\bgsa\/([\w\.]+) .*safari\//i                                      // Google Search Appliance on iOS
             ], [VERSION, [NAME, 'GSA'], [TYPE, INAPP]], [

--- a/src/main/ua-parser.js
+++ b/src/main/ua-parser.js
@@ -426,8 +426,7 @@
             /\b(line)\/([\w\.]+)\/iab/i,                                        // Line App for Android
             /(alipay)client\/([\w\.]+)/i,                                       // Alipay
             /(twitter)(?:and| f.+e\/([\w\.]+))/i,                               // Twitter
-            /(instagram|snapchat)[\/ ]([-\w\.]+)/i,                             // Instagram/Snapchat
-            /(zalo(?:app)?|zalo pay(?:client)?)[\/\sa-z]*([\w\.-]+)/i           // Zalo App
+            /(instagram|snapchat)[\/ ]([-\w\.]+)/i                              // Instagram/Snapchat
             ], [NAME, VERSION, [TYPE, INAPP]], [
             /\bgsa\/([\w\.]+) .*safari\//i                                      // Google Search Appliance on iOS
             ], [VERSION, [NAME, 'GSA'], [TYPE, INAPP]], [
@@ -435,6 +434,8 @@
             ], [VERSION, [NAME, 'TikTok'], [TYPE, INAPP]], [
             /\[(linkedin)app\]/i                                                // LinkedIn App for iOS & Android
             ], [NAME, [TYPE, INAPP]], [
+            /(zalo(?:app)?)[\/\sa-z]*([\w\.-]+)/i                               // Zalo 
+            ], [[NAME, /(.+)/, 'Zalo'], VERSION, [TYPE, INAPP]], [
 
             /(chromium)[\/ ]([-\w\.]+)/i                                        // Chromium
             ], [NAME, VERSION], [

--- a/test/data/ua/browser/browser-all.json
+++ b/test/data/ua/browser/browser-all.json
@@ -2697,27 +2697,5 @@
             "major"   : "20",
             "type"    : "inapp"
         }
-    },
-    {
-        "desc"    : "Zalo on iOS with CFNetwork",
-        "ua"      : "Zalo/205.0 CFNetwork/889.9 Darwin/17.2.0",
-        "expect"  :
-        {
-            "name"    : "Zalo",
-            "version" : "205.0",
-            "major"   : "205",
-            "type"    : "inapp"
-        }
-    },
-    {
-        "desc"    : "ZaloApp on Android",
-        "ua"      : "Mozilla/5.0 (Linux; Android 9; SM-G955F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 ZaloApp/23.02.01",
-        "expect"  :
-        {
-            "name"    : "Zalo",
-            "version" : "23.02.01",
-            "major"   : "23",
-            "type"    : "inapp"
-        }
     }
 ]

--- a/test/data/ua/browser/browser-all.json
+++ b/test/data/ua/browser/browser-all.json
@@ -2675,5 +2675,49 @@
             "major"   : "10",
             "type"    : "inapp"
         }
+    },
+    {
+        "desc"    : "Zalo on iOS",
+        "ua"      : "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Zalo/20.05.01 Mobile/15E148",
+        "expect"  :
+        {
+            "name"    : "Zalo",
+            "version" : "20.05.01",
+            "major"   : "20",
+            "type"    : "inapp"
+        }
+    },
+    {
+        "desc"    : "Zalo on Android",
+        "ua"      : "Mozilla/5.0 (Linux; Android 10; Vsmart Live Build/QKQ1.190918.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 Zalo/20.04.02.r1",
+        "expect"  :
+        {
+            "name"    : "Zalo",
+            "version" : "20.04.02.r1",
+            "major"   : "20",
+            "type"    : "inapp"
+        }
+    },
+    {
+        "desc"    : "Zalo on iOS with CFNetwork",
+        "ua"      : "Zalo/205.0 CFNetwork/889.9 Darwin/17.2.0",
+        "expect"  :
+        {
+            "name"    : "Zalo",
+            "version" : "205.0",
+            "major"   : "205",
+            "type"    : "inapp"
+        }
+    },
+    {
+        "desc"    : "ZaloApp on Android",
+        "ua"      : "Mozilla/5.0 (Linux; Android 9; SM-G955F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 ZaloApp/23.02.01",
+        "expect"  :
+        {
+            "name"    : "ZaloApp",
+            "version" : "23.02.01",
+            "major"   : "23",
+            "type"    : "inapp"
+        }
     }
 ]

--- a/test/data/ua/browser/browser-all.json
+++ b/test/data/ua/browser/browser-all.json
@@ -2714,7 +2714,7 @@
         "ua"      : "Mozilla/5.0 (Linux; Android 9; SM-G955F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 ZaloApp/23.02.01",
         "expect"  :
         {
-            "name"    : "ZaloApp",
+            "name"    : "Zalo",
             "version" : "23.02.01",
             "major"   : "23",
             "type"    : "inapp"


### PR DESCRIPTION
# Prerequisites

- [x] I have read and follow the [contributing](https://github.com/faisalman/ua-parser-js/blob/master/CONTRIBUTING.md) guidelines
- [x] I have read and accept the [Contributor License Agreement (CLA)](https://gist.github.com/faisalman/2ed16621ebb544157eba85a7f7381417) Document and I hereby sign the CLA

# Type of Change

Feature addition

# Description

Zalo is an app similar to WeChat used in Vietnam. With approximately 77.6 million monthly active users, it is used to scan [Zalo QR codes](https://qr.zalo.me/) opening different websites within Zalo inapp browser. Additionally, [Zalo mini-apps](https://mini.zalo.me/), which are [webapps](https://github.com/Zalo-MiniApp/miniapp-vue-template) run inside Zalo using the inapp browser. 

The ua-parser library currently lacks support for the Zalo inapp browser. This change adds detection for Zalo that would improve accuracy and benefit developers targeting this significant user base.

# Test

- Added a test for Zalo user-agent string. 

# Impact

- Breaking Changes: None
- User Actions: No changes required, backward compatibility maintained
